### PR TITLE
Recognize elif preprocessor directive

### DIFF
--- a/lib/XS/Check.pm
+++ b/lib/XS/Check.pm
@@ -256,6 +256,7 @@ check_hash_comments
 	my $hash = $1;
 	if ($hash !~ /^(?:
 			  define|
+			  elif|
 			  else|
 			  endif|
 			  error|


### PR DESCRIPTION
…to avoid spurious “Put whitespace before # in comments” complaint

Example: https://github.com/gisle/tcl.pm/blob/0f3b318efe/Tcl.xs

```
Tcl.xs:55: Put whitespace before # in comments.
Tcl.xs:57: Put whitespace before # in comments.
Tcl.xs:88: Put whitespace before # in comments.
Tcl.xs:100: Put whitespace before # in comments.
```