### PR TITLE
remove extraneous import

### DIFF
--- a/t/XSCT.pm
+++ b/t/XSCT.pm
@@ -20,7 +20,6 @@ sub import
     warnings->import ();
 
     Test::More->import ();
-    XS::Check->import (':all');
 
     XSCT->export_to_level (1);
 }


### PR DESCRIPTION
XS::Check does not have an import method, so calling it was relying on perl ignoring the import call. Future versions of perl will error when import is called with unhandled arguments.